### PR TITLE
I've addressed a SyntaxError in storage.js, removed localStorageWrapp…

### DIFF
--- a/install/install.js
+++ b/install/install.js
@@ -12,6 +12,24 @@ document.addEventListener('DOMContentLoaded', () => {
         if(installMessage) installMessage.textContent = 'Error: FileSystem API not available. Cannot proceed.';
         installButton.disabled = true;
         return;
+    } else if (!window.WebOSFileSystem.getDrive('A')) {
+        console.error('WebOSFileSystem is available, but Drive A is not initialized. localstorage-driver.js might have failed to load or register before storage.js.');
+        if(installMessage) installMessage.textContent = 'Error: Drive A is not available. Installation files might be missing or corrupted.';
+        installButton.disabled = true;
+        return;
+    }
+    // New check to see if Drive A's storage driver is actually present,
+    // which is now expected to be the os.drives.get('A:') instance.
+    // This is a more robust check post-refactor.
+    else {
+        const driveA = window.WebOSFileSystem.getDrive('A');
+        if (!driveA.storage || typeof driveA.storage.open !== 'function') { // Check for a key method of the new driver
+             console.error('Drive A is present but its underlying storage driver (localstorage-driver.js) seems to be missing or not correctly registered.');
+             if(installMessage) installMessage.textContent = 'Error: Critical storage component for Drive A is missing.';
+             installButton.disabled = true;
+             return;
+        }
+        console.log("WebOSFileSystem and Drive A appear to be correctly initialized.");
     }
 
     installButton.addEventListener('click', async () => {

--- a/public/js/desktop.js
+++ b/public/js/desktop.js
@@ -1,0 +1,59 @@
+// public/js/desktop.js
+
+class DesktopManager {
+    constructor() {
+        console.log("DesktopManager initialized.");
+        this.desktopElement = document.getElementById('desktop'); // Assuming an element with id="desktop" exists
+        if (!this.desktopElement) {
+            console.warn('Desktop element not found. UI operations might be limited.');
+        }
+        this._setupEventListeners();
+    }
+
+    _setupEventListeners() {
+        // Placeholder for desktop-related event listeners
+        // e.g., context menus, icon clicks (if icons are managed here)
+        console.log("Desktop event listeners would be set up here.");
+    }
+
+    addIcon(iconConfig) {
+        // Placeholder for adding an application icon to the desktop
+        if (!this.desktopElement) return;
+        const iconDiv = document.createElement('div');
+        iconDiv.className = 'desktop-icon';
+        iconDiv.textContent = iconConfig.name || 'New App';
+        // iconDiv.style.backgroundImage = `url(${iconConfig.iconUrl || 'default-icon.png'})`;
+        iconDiv.onclick = () => {
+            console.log(`Icon ${iconConfig.name} clicked.`);
+            // Logic to launch application or window
+            if (iconConfig.onclick) {
+                iconConfig.onclick();
+            }
+        };
+        this.desktopElement.appendChild(iconDiv);
+        console.log(`Added icon: ${iconConfig.name}`);
+    }
+
+    loadDesktop() {
+        // Placeholder for loading desktop state, icons, wallpaper etc.
+        console.log("Desktop loaded.");
+        // Example: Add a test icon
+        // this.addIcon({ name: 'Test App', onclick: () => alert('Test App Launched!') });
+    }
+}
+
+// Initialize the DesktopManager when the DOM is ready,
+// or if this script is loaded defer/async after main HTML.
+// For a more robust setup, this might be called by a main application script.
+if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', () => {
+        window.desktopManager = new DesktopManager();
+        window.desktopManager.loadDesktop();
+    });
+} else {
+    // DOMContentLoaded has already fired
+    window.desktopManager = new DesktopManager();
+    window.desktopManager.loadDesktop();
+}
+
+console.log("desktop.js loaded");

--- a/public/os-files/indexdb-driver.js
+++ b/public/os-files/indexdb-driver.js
@@ -1,0 +1,415 @@
+// public/os-files/indexdb-driver.js
+(function() {
+    if (!window.indexedDB) {
+        console.warn("IndexedDB not supported by this browser. IndexDB driver will not be available.");
+        return;
+    }
+
+    const DB_NAME = 'WebOS_IndDB_FS';
+    const METADATA_STORE_NAME = 'file_metadata';
+    const CONTENTS_STORE_NAME = 'file_contents';
+    const DB_VERSION = 1;
+
+    let dbPromise = null;
+    let fds = new Map();
+    let fdCounter = 0;
+    let closedFds = [];
+    let rootInitialized = false;
+
+    function openDB() {
+        if (dbPromise) return dbPromise;
+
+        dbPromise = new Promise((resolve, reject) => {
+            const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+            request.onerror = (event) => {
+                console.error("IndexedDB error:", event.target.error);
+                reject(event.target.error);
+            };
+
+            request.onupgradeneeded = (event) => {
+                const db = event.target.result;
+                if (!db.objectStoreNames.contains(METADATA_STORE_NAME)) {
+                    db.createObjectStore(METADATA_STORE_NAME, { keyPath: 'path' });
+                }
+                if (!db.objectStoreNames.contains(CONTENTS_STORE_NAME)) {
+                    db.createObjectStore(CONTENTS_STORE_NAME, { keyPath: 'path' });
+                }
+            };
+
+            request.onsuccess = (event) => {
+                const db = event.target.result;
+                resolve(db);
+            };
+        });
+        return dbPromise;
+    }
+
+    async function getRecord(storeName, path) {
+        const db = await openDB();
+        return new Promise((resolve, reject) => {
+            const transaction = db.transaction(storeName, 'readonly');
+            const store = transaction.objectStore(storeName);
+            const request = store.get(path);
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = (event) => {
+                console.error(`Error getting record from ${storeName}:`, event.target.error);
+                reject(event.target.error);
+            };
+        });
+    }
+
+    async function putRecord(storeName, record) {
+        const db = await openDB();
+        return new Promise((resolve, reject) => {
+            const transaction = db.transaction(storeName, 'readwrite');
+            const store = transaction.objectStore(storeName);
+            const request = store.put(record);
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = (event) => {
+                console.error(`Error putting record to ${storeName}:`, event.target.error);
+                reject(event.target.error);
+            };
+        });
+    }
+
+    async function deleteRecord(storeName, path) {
+        const db = await openDB();
+        return new Promise((resolve, reject) => {
+            const transaction = db.transaction(storeName, 'readwrite');
+            const store = transaction.objectStore(storeName);
+            const request = store.delete(path);
+            request.onsuccess = () => resolve(request.result);
+            request.onerror = (event) => {
+                console.error(`Error deleting record from ${storeName}:`, event.target.error);
+                reject(event.target.error);
+            };
+        });
+    }
+
+    function _formatPath(path) {
+        if (!path) path = '/';
+        let fPath = '/' + path.split(/\/+/).filter(Boolean).join('/');
+        if (fPath === '') fPath = '/'; // Root case
+        // Directories (except root) should end with a slash for consistency in this driver,
+        // but the provided spec implies paths like '/foo/' for metadata key.
+        // For this implementation, metadata paths will not have trailing slashes unless root.
+        // Content for directories will be stored with their path (e.g. '/foo/').
+        return fPath;
+    }
+
+    function _getParentPath(path) {
+        const parts = path.split('/').filter(Boolean);
+        if (parts.length <= 1) return '/'; // Parent of '/foo' or '/' is '/'
+        parts.pop();
+        return '/' + parts.join('/');
+    }
+
+    function _getFileName(path) {
+        return path.split('/').filter(Boolean).pop() || '';
+    }
+
+    async function _initializeRootIfNeeded() {
+        if (rootInitialized) return Promise.resolve();
+        try {
+            const rootMeta = await getRecord(METADATA_STORE_NAME, '/');
+            if (!rootMeta) {
+                const now = Date.now();
+                await putRecord(METADATA_STORE_NAME, {
+                    path: '/', type: 'dir', size: 0,
+                    created: now, modified: now, accessed: now
+                });
+                await putRecord(CONTENTS_STORE_NAME, { path: '/', content: '' }); // Empty dir listing
+            }
+            rootInitialized = true;
+        } catch (error) {
+            console.error("Error initializing root directory:", error);
+            // Potentially rethrow or handle so subsequent operations know init failed
+            throw error;
+        }
+    }
+
+    async function _updateParentDirectoryListing(parentPath, itemName, action) {
+        if (parentPath === itemName) return; // Cannot modify self in parent listing (e.g. root)
+
+        try {
+            const parentContentRecord = await getRecord(CONTENTS_STORE_NAME, parentPath);
+            let entries = [];
+            if (parentContentRecord && parentContentRecord.content) {
+                entries = parentContentRecord.content.split(',').filter(name => name.trim() !== '');
+            }
+
+            const initialLength = entries.length;
+            if (action === 'add') {
+                if (!entries.includes(itemName)) {
+                    entries.push(itemName);
+                }
+            } else if (action === 'remove') {
+                entries = entries.filter(entry => entry !== itemName);
+            }
+
+            if (action === 'add' || entries.length !== initialLength) {
+                await putRecord(CONTENTS_STORE_NAME, { path: parentPath, content: entries.join(',') });
+                // Update parent's modified time
+                const parentMeta = await getRecord(METADATA_STORE_NAME, parentPath);
+                if (parentMeta) {
+                    parentMeta.modified = Date.now();
+                    parentMeta.accessed = Date.now(); // Access also counts as modification of listing
+                    await putRecord(METADATA_STORE_NAME, parentMeta);
+                }
+            }
+        } catch (error) {
+            console.error(`Error updating parent directory listing for ${parentPath}:`, error);
+            throw error; // Re-throw to signal failure
+        }
+    }
+
+
+    const implementedDriverObject = {
+        _getDB: () => openDB(), // Mainly for internal use or debugging
+
+        driveSize: () => -1, // IndexedDB doesn't have a fixed size in this context
+
+        open: async function(path, ...flags) {
+            await _initializeRootIfNeeded();
+            const fPath = _formatPath(path);
+            try {
+                const metadata = await getRecord(METADATA_STORE_NAME, fPath);
+                if (!metadata) {
+                    console.warn(`open: Path not found '${fPath}'`);
+                    return -1;
+                }
+
+                let fd;
+                if (closedFds.length > 0) {
+                    fd = closedFds.pop();
+                } else {
+                    fd = fdCounter++;
+                }
+                fds.set(fd, { path: fPath, flags: flags, metadata: metadata });
+                return fd;
+            } catch (error) {
+                console.error(`open: Error opening path '${fPath}':`, error);
+                return -1;
+            }
+        },
+
+        close: function(fd) {
+            if (fds.has(fd)) {
+                fds.delete(fd);
+                closedFds.push(fd);
+                return 0;
+            }
+            return -1; // FD not found
+        },
+
+        stat: function(fd) {
+            const entry = fds.get(fd);
+            if (!entry) return null;
+            // Return a copy to prevent external modification of internal state
+            return { ...entry.metadata };
+        },
+
+        read: async function(fd) {
+            const entry = fds.get(fd);
+            if (!entry) { console.warn("read: FD not found"); return null; }
+            // if (!entry.flags.includes('read')) { console.warn("read: No read flag"); return null; }
+
+
+            try {
+                const contentRecord = await getRecord(CONTENTS_STORE_NAME, entry.path);
+                if (!contentRecord) {
+                     // For directories, content might be empty string. For files, this means no content.
+                    if (entry.metadata.type === 'dir') return '';
+                    console.warn(`read: Content not found for path '${entry.path}'`);
+                    return null;
+                }
+
+                // Update accessed time for both files and directories
+                entry.metadata.accessed = Date.now();
+                await putRecord(METADATA_STORE_NAME, entry.metadata);
+                // Also update the stored metadata in the FD map
+                fds.set(fd, {...entry, metadata: entry.metadata});
+
+                return contentRecord.content;
+            } catch (error) {
+                console.error(`read: Error reading content for path '${entry.path}':`, error);
+                return null;
+            }
+        },
+
+        write: async function(fd, data) {
+            const entry = fds.get(fd);
+            if (!entry) { console.warn("write: FD not found"); return -1; }
+            // if (!entry.flags.includes('write')) { console.warn("write: No write flag"); return -1; }
+
+            try {
+                await putRecord(CONTENTS_STORE_NAME, { path: entry.path, content: data });
+
+                entry.metadata.modified = Date.now();
+                entry.metadata.accessed = Date.now();
+                if (entry.metadata.type === 'file') {
+                    entry.metadata.size = data.length;
+                }
+                // If type is 'dir', size is 0 or represents number of items, not content string length.
+                // The current spec implies dir size is 0. The content of a dir (listing) is handled.
+
+                await putRecord(METADATA_STORE_NAME, entry.metadata);
+                 // Also update the stored metadata in the FD map
+                fds.set(fd, {...entry, metadata: entry.metadata});
+
+                return entry.metadata.type === 'file' ? data.length : 0;
+            } catch (error) {
+                console.error(`write: Error writing content to path '${entry.path}':`, error);
+                return -1;
+            }
+        },
+
+        mkdir: async function(path) {
+            await _initializeRootIfNeeded();
+            const fPath = _formatPath(path);
+            const parentPath = _getParentPath(fPath);
+            const itemName = _getFileName(fPath);
+
+            if (fPath === '/') { console.warn("mkdir: Cannot create root."); return -1; } // Root already handled
+
+            try {
+                let existingMeta = await getRecord(METADATA_STORE_NAME, fPath);
+                if (existingMeta) {
+                    console.warn(`mkdir: Path already exists '${fPath}' as type ${existingMeta.type}`);
+                    return -1; // Path already exists
+                }
+
+                const parentMeta = await getRecord(METADATA_STORE_NAME, parentPath);
+                if (!parentMeta || parentMeta.type !== 'dir') {
+                    console.warn(`mkdir: Parent path '${parentPath}' not found or not a directory.`);
+                    return -1;
+                }
+
+                const now = Date.now();
+                const newDirMeta = {
+                    path: fPath, type: 'dir', size: 0,
+                    created: now, modified: now, accessed: now
+                };
+                await putRecord(METADATA_STORE_NAME, newDirMeta);
+                await putRecord(CONTENTS_STORE_NAME, { path: fPath, content: '' }); // Empty dir listing
+
+                await _updateParentDirectoryListing(parentPath, itemName, 'add');
+                return 0; // Success
+            } catch (error) {
+                console.error(`mkdir: Error creating directory '${fPath}':`, error);
+                return -1;
+            }
+        },
+
+        create: async function(path) { // For files
+            await _initializeRootIfNeeded();
+            const fPath = _formatPath(path);
+            const parentPath = _getParentPath(fPath);
+            const itemName = _getFileName(fPath);
+
+            if (fPath === '/') { console.warn("create: Cannot create file at root path directly."); return -1; }
+
+
+            try {
+                let existingMeta = await getRecord(METADATA_STORE_NAME, fPath);
+                if (existingMeta) {
+                    console.warn(`create: Path already exists '${fPath}' as type ${existingMeta.type}`);
+                    return -1; // Path already exists (could be file or dir)
+                }
+
+                const parentMeta = await getRecord(METADATA_STORE_NAME, parentPath);
+                if (!parentMeta || parentMeta.type !== 'dir') {
+                    console.warn(`create: Parent path '${parentPath}' not found or not a directory.`);
+                    return -1;
+                }
+
+                const now = Date.now();
+                const newFileMeta = {
+                    path: fPath, type: 'file', size: 0,
+                    created: now, modified: now, accessed: now
+                };
+                await putRecord(METADATA_STORE_NAME, newFileMeta);
+                await putRecord(CONTENTS_STORE_NAME, { path: fPath, content: '' }); // Empty content
+
+                await _updateParentDirectoryListing(parentPath, itemName, 'add');
+                return 0; // Success
+            } catch (error) {
+                console.error(`create: Error creating file '${fPath}':`, error);
+                return -1;
+            }
+        },
+
+        delete: async function(path) { // File only as per spec
+            await _initializeRootIfNeeded();
+            const fPath = _formatPath(path);
+            const parentPath = _getParentPath(fPath);
+            const itemName = _getFileName(fPath);
+
+            try {
+                const metadata = await getRecord(METADATA_STORE_NAME, fPath);
+                if (!metadata) {
+                    console.warn(`delete: Path not found '${fPath}'`);
+                    return -1;
+                }
+                if (metadata.type !== 'file') {
+                    console.warn(`delete: Path '${fPath}' is not a file. Type: ${metadata.type}. Deletion of directories not supported by this specific 'delete' method.`);
+                    return -1;
+                }
+
+                await deleteRecord(CONTENTS_STORE_NAME, fPath);
+                await deleteRecord(METADATA_STORE_NAME, fPath);
+
+                await _updateParentDirectoryListing(parentPath, itemName, 'remove');
+
+                // Close any open FDs for this path
+                fds.forEach((fdEntry, fd) => {
+                    if (fdEntry.path === fPath) {
+                        this.close(fd);
+                    }
+                });
+
+                return 0; // Success
+            } catch (error) {
+                console.error(`delete: Error deleting file '${fPath}':`, error);
+                return -1;
+            }
+        },
+
+        readdir: async function(fd) {
+            const entry = fds.get(fd);
+            if (!entry || entry.metadata.type !== 'dir') {
+                console.warn("readdir: FD not found or not a directory.");
+                return null;
+            }
+
+            try {
+                const dirContent = await this.read(fd); // read(fd) handles access time update
+                if (dirContent === null) return null; // Error occurred in read
+                if (dirContent === '') return []; // Empty directory
+                return dirContent.split(',').filter(name => name.trim() !== '');
+            } catch (error) {
+                console.error(`readdir: Error processing directory content for '${entry.path}':`, error);
+                return null;
+            }
+        }
+    };
+
+    // Register the driver
+    if (window.os && window.os.drives) {
+        // Ensure openDB is called once at registration to initialize if needed,
+        // and to allow _initializeRootIfNeeded to run early.
+        openDB().then(() => {
+             _initializeRootIfNeeded().then(() => {
+                window.os.drives.set('B:', implementedDriverObject);
+                console.log("IndexedDB driver registered for Drive B and root initialized.");
+             }).catch(err => {
+                console.error("Failed to initialize root for IndexedDB driver:", err);
+             });
+        }).catch(error => {
+            console.error("Failed to open IndexedDB for driver registration:", error);
+        });
+    } else {
+        console.error("Main OS object (window.os.drives) not found. Cannot register IndexedDB driver.");
+    }
+})();

--- a/public/os-files/localstorage-driver.js
+++ b/public/os-files/localstorage-driver.js
@@ -18,7 +18,7 @@ os.drives.set('A:', {
 
         let fd = -1
 
-        if (!(fpath in table)) {
+        if (!(fpath in drive.table)) { // Corrected 'table' to 'drive.table'
             return -1
         }
 
@@ -126,6 +126,67 @@ os.drives.set('A:', {
         }
 
         save()
+    },
+
+    delete(path) {
+        const fpath = format(path); // Use existing format function
+
+        // 1. Check if path exists in drive.table
+        if (!(fpath in drive.table)) {
+            console.warn(`delete: Path not found '${fpath}'`);
+            return -1; // Error: Not found
+        }
+
+        // 2. Check if it's a file
+        if (drive.table[fpath].type !== 'file') {
+            console.warn(`delete: Path '${fpath}' is not a file. Type: ${drive.table[fpath].type}`);
+            return -1; // Error: Not a file
+        }
+
+        // 3. Attempt to remove from localStorage
+        try {
+            localStorage.removeItem(fpath); // Assuming files are stored with their full formatted path as key
+        } catch (e) {
+            console.error(`delete: Error removing item from localStorage for path '${fpath}':`, e);
+            return -1; // Error: localStorage removal failed
+        }
+
+        // 4. Remove from drive.table
+        delete drive.table[fpath];
+
+        // 5. Update parent directory listing
+        const ppath = parent(fpath); // Use existing parent function
+        if (ppath && ppath in drive.table && drive.table[ppath].type === 'dir') {
+            // Read parent directory content from localStorage
+            // Note: The current driver's read/write operates on FDs.
+            // This is a direct manipulation for simplicity, bypassing FD logic for this internal update.
+            // A more robust implementation might use open/read/write for parent dir.
+            let parentContent = localStorage.getItem(ppath);
+            if (parentContent !== null) {
+                let parentEntries = parentContent.split(',').filter(name => name.trim() !== '');
+                const filename = fname(fpath); // Use existing fname function
+                const initialLength = parentEntries.length;
+                parentEntries = parentEntries.filter(entry => entry !== filename);
+
+                if (parentEntries.length !== initialLength) {
+                    localStorage.setItem(ppath, parentEntries.join(','));
+                    // Update parent directory's size if it's tracked based on content length
+                    // For now, size of dir is 0, so no change needed for that.
+                } else {
+                    console.warn(`delete: Filename '${filename}' not found in parent directory listing '${ppath}'.`);
+                }
+            } else {
+                console.warn(`delete: Parent directory content for '${ppath}' not found in localStorage.`);
+            }
+        } else {
+            console.warn(`delete: Parent directory '${ppath}' not found or not a directory.`);
+        }
+
+        // 6. Save drive metadata
+        save(); // Use existing save function
+
+        console.log(`delete: File '${fpath}' deleted successfully.`);
+        return 0; // Success
     }
 });
 


### PR DESCRIPTION
…er, and implemented new file system features.

Here's a summary of what I changed:
- I fixed a SyntaxError in storage.js that was due to a missing catch block.
- I removed the old localStorageWrapper from storage.js. Drive A will now only use the 'os.drives' localStorage driver. The persistentStorageWrapper will now default to IndexedDB if it's available.
- I created a placeholder file at public/js/desktop.js.
- I added a delete(path) method in public/os-files/localstorage-driver.js for deleting files and updated FileSystem.deleteFile to use this new method.
- I implemented a new IndexedDB-based file system driver in public/os-files/indexdb-driver.js, which is now registered as Drive B.
- I updated install/install.js with more thorough checks for WebOSFileSystem and Drive A initialization to help prevent errors when you're installing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a desktop-like UI with dynamic icon management and initialization.
  - Added a new IndexedDB-based filesystem driver for enhanced storage support (Drive B:).
  - Added support for file deletion in the localStorage-based filesystem driver (Drive A:).

- **Bug Fixes**
  - Fixed an issue in the localStorage driver where file operations incorrectly referenced an undefined variable.

- **Refactor**
  - Removed legacy localStorage-based storage logic and fully transitioned to the new driver architecture.
  - Improved validation and error handling when initializing storage drives and drivers.

- **Chores**
  - Deprecated and removed internal methods and utilities related to the old storage system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->